### PR TITLE
Implement additional SEO and performance safeguards

### DIFF
--- a/src/Admin/AdminBarBadge.php
+++ b/src/Admin/AdminBarBadge.php
@@ -19,6 +19,7 @@ use function add_action;
 use function add_query_arg;
 use function admin_url;
 use function current_user_can;
+use function esc_attr;
 use function get_post;
 use function get_post_meta;
 use function get_post_type;
@@ -107,17 +108,19 @@ class AdminBarBadge {
 						),
 						admin_url( 'admin.php' )
 					),
-					'meta'  => array(
-						'class' => 'fp-seo-performance-badge fp-seo-performance-badge--' . sanitize_html_class( $score_status ),
-						'title' => sprintf(
-							'%s: %s',
-							I18n::translate( 'Analyzer status' ),
-							$this->status_description( $score_status )
-						),
-					),
-				)
-			);
-	}
+                                        'meta'  => array(
+                                                'class' => 'fp-seo-performance-badge fp-seo-performance-badge--' . sanitize_html_class( $score_status ),
+                                                'title' => esc_attr(
+                                                        sprintf(
+                                                                '%s: %s',
+                                                                I18n::translate( 'Analyzer status' ),
+                                                                $this->status_description( $score_status )
+                                                        )
+                                                ),
+                                        ),
+                                )
+                        );
+        }
 
 		/**
 		 * Determine whether the badge should render for the current request.

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -320,17 +320,27 @@ class SettingsPage {
 			<tr>
 				<th scope="row"><?php esc_html_e( 'Local heuristics', 'fp-seo-performance' ); ?></th>
 				<td>
-					<label>
-						<input type="checkbox" name="<?php echo esc_attr( Options::OPTION_KEY ); ?>[performance][heuristics][images_missing_dimensions]" value="1" <?php checked( $performance['heuristics']['images_missing_dimensions'] ); ?> />
-						<?php esc_html_e( 'Warn when images miss width/height attributes.', 'fp-seo-performance' ); ?>
-					</label>
-					<br />
-					<label>
-						<input type="checkbox" name="<?php echo esc_attr( Options::OPTION_KEY ); ?>[performance][heuristics][large_dom]" value="1" <?php checked( $performance['heuristics']['large_dom'] ); ?> />
-						<?php esc_html_e( 'Highlight pages with unusually large DOM trees.', 'fp-seo-performance' ); ?>
-					</label>
-				</td>
-			</tr>
+                                        <label>
+                                                <input type="checkbox" name="<?php echo esc_attr( Options::OPTION_KEY ); ?>[performance][heuristics][image_alt_coverage]" value="1" <?php checked( $performance['heuristics']['image_alt_coverage'] ); ?> />
+                                                <?php esc_html_e( 'Monitor image alternative text coverage.', 'fp-seo-performance' ); ?>
+                                        </label>
+                                        <br />
+                                        <label>
+                                                <input type="checkbox" name="<?php echo esc_attr( Options::OPTION_KEY ); ?>[performance][heuristics][inline_css]" value="1" <?php checked( $performance['heuristics']['inline_css'] ); ?> />
+                                                <?php esc_html_e( 'Flag large inline CSS blocks.', 'fp-seo-performance' ); ?>
+                                        </label>
+                                        <br />
+                                        <label>
+                                                <input type="checkbox" name="<?php echo esc_attr( Options::OPTION_KEY ); ?>[performance][heuristics][image_count]" value="1" <?php checked( $performance['heuristics']['image_count'] ); ?> />
+                                                <?php esc_html_e( 'Warn when pages embed many images.', 'fp-seo-performance' ); ?>
+                                        </label>
+                                        <br />
+                                        <label>
+                                                <input type="checkbox" name="<?php echo esc_attr( Options::OPTION_KEY ); ?>[performance][heuristics][heading_depth]" value="1" <?php checked( $performance['heuristics']['heading_depth'] ); ?> />
+                                                <?php esc_html_e( 'Highlight deeply nested heading structures.', 'fp-seo-performance' ); ?>
+                                        </label>
+                                </td>
+                        </tr>
 			</tbody>
 		</table>
 		<?php
@@ -386,15 +396,9 @@ class SettingsPage {
 	 *
 	 * @return array<string, string> Map of locale codes to labels.
 	 */
-	private function get_language_choices(): array {
-		return array(
-			'en' => __( 'English', 'fp-seo-performance' ),
-			'es' => __( 'Spanish', 'fp-seo-performance' ),
-			'fr' => __( 'French', 'fp-seo-performance' ),
-			'de' => __( 'German', 'fp-seo-performance' ),
-			'it' => __( 'Italian', 'fp-seo-performance' ),
-		);
-	}
+        private function get_language_choices(): array {
+                return Options::get_language_choices();
+        }
 
 	/**
 	 * Resolves a human readable label for a check key.

--- a/src/Analysis/Checks/OgCardsCheck.php
+++ b/src/Analysis/Checks/OgCardsCheck.php
@@ -49,17 +49,21 @@ class OgCardsCheck implements CheckInterface {
 	 * @return Result
 	 */
 	public function run( Context $context ): Result {
-		$required = array( 'og:title', 'og:description', 'og:type', 'og:url' );
-		$missing  = array();
-		$present  = array();
+                $required = array( 'og:title', 'og:description', 'og:type', 'og:url', 'og:image' );
+                $missing  = array();
+                $present  = array();
 
-		foreach ( $required as $key ) {
-			$value = (string) $context->meta_content( 'property', $key );
+                foreach ( $required as $key ) {
+                        $value = (string) $context->meta_content( 'property', $key );
 
-			if ( '' === trim( $value ) ) {
-				$missing[] = $key;
-				continue;
-			}
+                        if ( 'og:image' === $key && '' === trim( $value ) ) {
+                                $value = (string) $context->meta_content( 'property', 'og:image:secure_url' );
+                        }
+
+                        if ( '' === trim( $value ) ) {
+                                $missing[] = $key;
+                                continue;
+                        }
 
 			$present[ $key ] = $value;
 		}
@@ -76,7 +80,7 @@ class OgCardsCheck implements CheckInterface {
 		}
 
 		$status = count( $missing ) > 2 ? Result::STATUS_FAIL : Result::STATUS_WARN;
-		$hint   = I18n::translate( 'Add missing Open Graph tags for better social sharing previews.' );
+                $hint   = I18n::translate( 'Add missing Open Graph tags (title, description, URL, or image) to improve social sharing previews.' );
 
 		return new Result(
 			$status,

--- a/src/Analysis/Checks/TwitterCardsCheck.php
+++ b/src/Analysis/Checks/TwitterCardsCheck.php
@@ -49,17 +49,21 @@ class TwitterCardsCheck implements CheckInterface {
 	 * @return Result
 	 */
 	public function run( Context $context ): Result {
-		$required = array( 'twitter:card', 'twitter:title', 'twitter:description' );
-		$missing  = array();
-		$present  = array();
+                $required = array( 'twitter:card', 'twitter:title', 'twitter:description', 'twitter:image' );
+                $missing  = array();
+                $present  = array();
 
-		foreach ( $required as $key ) {
-			$value = (string) $context->meta_content( 'name', $key );
+                foreach ( $required as $key ) {
+                        $value = (string) $context->meta_content( 'name', $key );
 
-			if ( '' === trim( $value ) ) {
-				$missing[] = $key;
-				continue;
-			}
+                        if ( 'twitter:image' === $key && '' === trim( $value ) ) {
+                                $value = (string) $context->meta_content( 'name', 'twitter:image:src' );
+                        }
+
+                        if ( '' === trim( $value ) ) {
+                                $missing[] = $key;
+                                continue;
+                        }
 
 			$present[ $key ] = $value;
 		}
@@ -76,7 +80,7 @@ class TwitterCardsCheck implements CheckInterface {
 		}
 
 		$status = count( $missing ) >= 2 ? Result::STATUS_FAIL : Result::STATUS_WARN;
-		$hint   = I18n::translate( 'Add missing Twitter card tags to control social previews.' );
+                $hint   = I18n::translate( 'Add missing Twitter card tags (card type, title, description, or image) to control social previews.' );
 
 		return new Result(
 			$status,

--- a/src/Analysis/Context.php
+++ b/src/Analysis/Context.php
@@ -284,40 +284,8 @@ class Context {
 	 * @return array<int, array{level:int,text:string}>
 	 */
 	public function headings(): array {
-		$dom = $this->dom();
-
-		if ( null === $dom ) {
-			return array();
-		}
-
-		$result = array();
-
-		for ( $level = 1; $level <= 6; $level++ ) {
-			$tag   = 'h' . $level;
-			$nodes = $dom->getElementsByTagName( $tag );
-
-			foreach ( $nodes as $node ) {
-								/**
-								 * DOM element instance.
-								 *
-								 * @var DOMElement $node
-								 */
-								$result[] = array(
-									'level' => $level,
-									'text'  => trim( $node->{'textContent'} ?? '' ),
-								);
-			}
-		}
-
-		usort(
-			$result,
-			static function ( array $a, array $b ): int {
-				return $a['level'] <=> $b['level'];
-			}
-		);
-
-		return $result;
-	}
+                return $this->ordered_headings();
+        }
 
 	/**
 	 * Retrieve all heading elements preserving document order.

--- a/src/Editor/Metabox.php
+++ b/src/Editor/Metabox.php
@@ -26,6 +26,7 @@ use function get_current_screen;
 use function get_post_meta;
 use function get_post_types;
 use function in_array;
+use function esc_url_raw;
 use function is_array;
 use function sanitize_text_field;
 use function update_post_meta;
@@ -236,7 +237,7 @@ class Metabox {
 		$title     = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['title'] ) ) : '';
 		$excerpt   = isset( $_POST['excerpt'] ) ? wp_kses_post( wp_unslash( (string) $_POST['excerpt'] ) ) : '';
 		$meta      = isset( $_POST['metaDescription'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['metaDescription'] ) ) : '';
-		$canonical = isset( $_POST['canonical'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['canonical'] ) ) : null;
+                $canonical = isset( $_POST['canonical'] ) ? esc_url_raw( wp_unslash( (string) $_POST['canonical'] ) ) : null;
 		$robots    = isset( $_POST['robots'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['robots'] ) ) : null;
 
 		if ( '' === $meta ) {

--- a/src/SiteHealth/SeoHealth.php
+++ b/src/SiteHealth/SeoHealth.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace FP\SEO\SiteHealth;
 
 use FP\SEO\Utils\Options;
+use function wp_remote_retrieve_response_code;
 
 /**
  * Registers Site Health checks for the plugin.
@@ -75,7 +76,29 @@ class SeoHealth {
 			);
 		}
 
-		$body = (string) wp_remote_retrieve_body( $response );
+                $status_code = (int) wp_remote_retrieve_response_code( $response );
+
+                if ( 200 !== $status_code ) {
+                        return array(
+                                'label'       => __( 'Homepage returned an unexpected HTTP status', 'fp-seo-performance' ),
+                                'status'      => 'critical',
+                                'badge'       => $badge,
+                                'description' => sprintf(
+                                        /* translators: %d: HTTP status code. */
+                                        __( 'The homepage responded with HTTP %d so SEO metadata could not be verified. Resolve the issue and try again.', 'fp-seo-performance' ),
+                                        $status_code
+                                ),
+                                'actions'     => array(
+                                        sprintf(
+                                                '<a href="%s" target="_blank" rel="noopener">%s</a>',
+                                                esc_url( $home_url ),
+                                                esc_html__( 'Open homepage', 'fp-seo-performance' )
+                                        ),
+                                ),
+                        );
+                }
+
+                $body = (string) wp_remote_retrieve_body( $response );
 
 		if ( '' === trim( $body ) ) {
 			return array(

--- a/src/Utils/Options.php
+++ b/src/Utils/Options.php
@@ -17,7 +17,22 @@ class Options {
 	public const OPTION_KEY   = 'fp_seo_perf_options';
 	public const OPTION_GROUP = 'fp_seo_performance';
 
-	private const DEFAULT_LANGUAGE = 'en';
+        private const DEFAULT_LANGUAGE = 'en';
+
+        /**
+         * Provides the available UI languages.
+         *
+         * @return array<string, string>
+         */
+        public static function get_language_choices(): array {
+                return array(
+                        'en' => __( 'English', 'fp-seo-performance' ),
+                        'es' => __( 'Spanish', 'fp-seo-performance' ),
+                        'fr' => __( 'French', 'fp-seo-performance' ),
+                        'de' => __( 'German', 'fp-seo-performance' ),
+                        'it' => __( 'Italian', 'fp-seo-performance' ),
+                );
+        }
 
 	/**
 	 * Keys available for analysis checks toggles.
@@ -86,14 +101,16 @@ class Options {
 			'scoring'     => array(
 				'weights' => self::default_scoring_weights(),
 			),
-			'performance' => array(
-				'enable_psi'  => false,
-				'psi_api_key' => '',
-				'heuristics'  => array(
-					'images_missing_dimensions' => true,
-					'large_dom'                 => true,
-				),
-			),
+                        'performance' => array(
+                                'enable_psi'  => false,
+                                'psi_api_key' => '',
+                                'heuristics'  => array(
+                                        'image_alt_coverage' => true,
+                                        'inline_css'         => true,
+                                        'image_count'        => true,
+                                        'heading_depth'      => true,
+                                ),
+                        ),
 			'advanced'    => array(
 				'capability'        => 'manage_options',
 				'telemetry_enabled' => false,
@@ -432,19 +449,23 @@ class Options {
 	 * @param string $value Raw language input.
 	 */
 	private static function sanitize_language( string $value ): string {
-		$value = strtolower( trim( $value ) );
-		$value = preg_replace( '/[^a-z\-]/', '', $value );
+                $value = strtolower( trim( $value ) );
+                $value = preg_replace( '/[^a-z\-]/', '', $value );
 
-		if ( ! is_string( $value ) || '' === $value ) {
-			return self::DEFAULT_LANGUAGE;
-		}
+                if ( ! is_string( $value ) || '' === $value ) {
+                        return self::DEFAULT_LANGUAGE;
+                }
 
-		if ( strlen( $value ) > 10 ) {
-			$value = substr( $value, 0, 10 );
-		}
+                if ( strlen( $value ) > 10 ) {
+                        $value = substr( $value, 0, 10 );
+                }
 
-		return $value;
-	}
+                if ( ! isset( self::get_language_choices()[ $value ] ) ) {
+                        return self::DEFAULT_LANGUAGE;
+                }
+
+                return $value;
+        }
 
 	/**
 	 * Sanitizes plain text values.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,3 +24,4 @@ if ( ! function_exists( 'tests_add_filter' ) ) {
 			return add_filter( $tag, $function_to_add, $priority, $accepted_args );
 	}
 }
+

--- a/tests/unit/Admin/AdminBarBadgeTest.php
+++ b/tests/unit/Admin/AdminBarBadgeTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Admin bar badge tests.
+ *
+ * @package FP\SEO\Tests
+ */
+
+declare(strict_types=1);
+
+namespace {
+        if ( ! class_exists( 'WP_Admin_Bar' ) ) {
+                class WP_Admin_Bar {
+                        /** @var array<int, array<string, mixed>> */
+                        public array $nodes = array();
+
+                        public function add_node( array $args ): void {
+                                $this->nodes[] = $args;
+                        }
+                }
+        }
+}
+
+namespace FP\SEO\Tests\Unit\Admin {
+
+use Brain\Monkey;
+use FP\SEO\Admin\AdminBarBadge;
+use PHPUnit\Framework\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \FP\SEO\Admin\AdminBarBadge
+ */
+class AdminBarBadgeTest extends TestCase {
+        /**
+         * Prepare Brain Monkey stubs.
+         */
+        protected function setUp(): void {
+                parent::setUp();
+                Monkey\setUp();
+
+                when( 'is_admin' )->justReturn( true );
+                when( 'is_admin_bar_showing' )->justReturn( true );
+                when( 'current_user_can' )->justReturn( true );
+                when( 'esc_html' )->returnArg( 1 );
+                when( 'esc_attr' )->alias(
+                        static function ( string $text ): string {
+                                return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+                        }
+                );
+                when( 'esc_url' )->returnArg( 1 );
+                when( 'esc_html__' )->returnArg( 1 );
+                when( 'sanitize_html_class' )->returnArg( 1 );
+                when( 'admin_url' )->alias(
+                        static function ( string $path = '' ): string {
+                                return 'https://example.com/wp-admin/' . ltrim( $path, '/' );
+                        }
+                );
+                when( 'add_query_arg' )->alias(
+                        static function ( array $args, string $url ): string {
+                                return $url . '?' . http_build_query( $args );
+                        }
+                );
+                when( 'home_url' )->alias(
+                        static function ( string $path = '/' ): string {
+                                return 'https://example.com' . $path;
+                        }
+                );
+                when( 'get_option' )->alias(
+                        static function ( string $option, $default = false ) {
+                                if ( 'fp_seo_perf_options' === $option ) {
+                                        return array(
+                                                'general' => array(
+                                                        'enable_analyzer' => true,
+                                                        'language'        => 'en',
+                                                        'admin_bar_badge' => true,
+                                                ),
+                                        );
+                                }
+
+                                return $default;
+                        }
+                );
+                when( 'get_post' )->alias(
+                        static function ( $post_id ) {
+                                return (object) array(
+                                        'ID'           => (int) $post_id,
+                                        'post_content' => str_repeat( 'Word ', 200 ) . '<a href="/internal">Link</a>',
+                                        'post_title'   => 'Sample Title',
+                                        'post_excerpt' => 'Summary',
+                                );
+                        }
+                );
+                when( 'get_post_type' )->justReturn( 'post' );
+                when( 'get_post_meta' )->justReturn( '' );
+                when( 'get_permalink' )->alias(
+                        static function (): string {
+                                return 'https://example.com/post';
+                        }
+                );
+                when( 'wp_strip_all_tags' )->alias( 'strip_tags' );
+                when( '__' )->alias(
+                        static function ( string $text ) {
+                                if ( 'Critical issues' === $text ) {
+                                        return '"><script>alert(1)</script';
+                                }
+
+                                return $text;
+                        }
+                );
+        }
+
+        /**
+         * Clean up Brain Monkey state.
+         */
+        protected function tearDown(): void {
+                Monkey\tearDown();
+                parent::tearDown();
+        }
+
+        /**
+         * Ensures the tooltip string is properly escaped.
+         */
+        public function test_add_badge_escapes_tooltip_attribute(): void {
+                global $pagenow;
+
+                $pagenow      = 'post.php';
+                $_GET['post'] = '123';
+
+                $bar   = new \WP_Admin_Bar();
+                $badge = new AdminBarBadge();
+                $badge->add_badge( $bar );
+
+                self::assertNotEmpty( $bar->nodes );
+                $meta = $bar->nodes[0]['meta'];
+
+                self::assertArrayHasKey( 'title', $meta );
+                self::assertStringNotContainsString( '<script', $meta['title'] );
+                self::assertStringContainsString( '&lt;script', $meta['title'] );
+        }
+}
+
+}

--- a/tests/unit/Analysis/AnalyzerTest.php
+++ b/tests/unit/Analysis/AnalyzerTest.php
@@ -9,17 +9,32 @@ declare(strict_types=1);
 
 namespace FP\SEO\Tests\Unit\Analysis;
 
+use Brain\Monkey;
 use FP\SEO\Analysis\Analyzer;
 use FP\SEO\Analysis\CheckInterface;
 use FP\SEO\Analysis\Context;
 use FP\SEO\Analysis\Result;
 use PHPUnit\Framework\TestCase;
+use function Brain\Monkey\Functions\when;
 use const JSON_UNESCAPED_SLASHES;
 
 /**
  * Analyzer integration smoke test.
  */
 final class AnalyzerTest extends TestCase {
+        protected function setUp(): void {
+                parent::setUp();
+                Monkey\setUp();
+                when( '__' )->returnArg( 1 );
+                when( 'esc_html__' )->returnArg( 1 );
+                when( 'home_url' )->justReturn( 'https://example.com/' );
+                when( 'wp_strip_all_tags' )->alias( 'strip_tags' );
+        }
+
+        protected function tearDown(): void {
+                Monkey\tearDown();
+                parent::tearDown();
+        }
 	/**
 	 * Ensures analyzer executes all checks and aggregates results.
 	 *
@@ -28,21 +43,23 @@ final class AnalyzerTest extends TestCase {
 	public function test_runs_all_checks_and_aggregates_summary(): void {
 		$meta_description = str_repeat( 'Helpful search description offering clarity and context. ', 2 ) . 'Encourages clicks with compelling value.';
 		$content          = str_repeat( 'Insightful content supporting the analyzer evaluation. ', 40 );
-		$html             = '<html><head>'
-		. '<meta name="description" content="' . $meta_description . '" />'
-		. '<meta name="robots" content="index,follow" />'
-		. '<link rel="canonical" href="https://example.com/sample-page" />'
-		. '<meta property="og:title" content="OG Title" />'
-		. '<meta property="og:description" content="OG description content." />'
-		. '<meta property="og:type" content="article" />'
-		. '<meta property="og:url" content="https://example.com/sample-page" />'
-		. '<meta name="twitter:card" content="summary_large_image" />'
-		. '<meta name="twitter:title" content="Twitter Title" />'
-		. '<meta name="twitter:description" content="Twitter description goes here." />'
-		. '<script type="application/ld+json">' . json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
-			array(
-				'@context' => 'https://schema.org',
-				'@type'    => array( 'Organization', 'WebSite', 'BlogPosting' ),
+                $html             = '<html><head>'
+                . '<meta name="description" content="' . $meta_description . '" />'
+                . '<meta name="robots" content="index,follow" />'
+                . '<link rel="canonical" href="https://example.com/sample-page" />'
+                . '<meta property="og:title" content="OG Title" />'
+                . '<meta property="og:description" content="OG description content." />'
+                . '<meta property="og:type" content="article" />'
+                . '<meta property="og:url" content="https://example.com/sample-page" />'
+                . '<meta property="og:image" content="https://example.com/og-image.jpg" />'
+                . '<meta name="twitter:card" content="summary_large_image" />'
+                . '<meta name="twitter:title" content="Twitter Title" />'
+                . '<meta name="twitter:description" content="Twitter description goes here." />'
+                . '<meta name="twitter:image" content="https://example.com/twitter-image.jpg" />'
+                . '<script type="application/ld+json">' . json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+                        array(
+                                '@context' => 'https://schema.org',
+                                '@type'    => array( 'Organization', 'WebSite', 'BlogPosting' ),
 				'name'     => 'Example',
 			),
 			JSON_UNESCAPED_SLASHES

--- a/tests/unit/Analysis/ContextHeadingsTest.php
+++ b/tests/unit/Analysis/ContextHeadingsTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Context heading helpers tests.
+ *
+ * @package FP\SEO\Tests
+ */
+
+declare(strict_types=1);
+
+namespace FP\SEO\Tests\Unit\Analysis;
+
+use FP\SEO\Analysis\Context;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \FP\SEO\Analysis\Context::headings
+ */
+class ContextHeadingsTest extends TestCase {
+        public function test_headings_preserve_document_order(): void {
+                $html    = '<h2>Second</h2><h1>First</h1><h3>Third</h3>';
+                $context = new Context( null, $html );
+
+                $headings = $context->headings();
+
+                self::assertSame( array( 2, 1, 3 ), array_column( $headings, 'level' ) );
+                self::assertSame( array( 'Second', 'First', 'Third' ), array_column( $headings, 'text' ) );
+        }
+}

--- a/tests/unit/Analysis/ImageAltCheckTest.php
+++ b/tests/unit/Analysis/ImageAltCheckTest.php
@@ -9,15 +9,28 @@ declare(strict_types=1);
 
 namespace FP\SEO\Tests\Unit\Analysis;
 
+use Brain\Monkey;
 use FP\SEO\Analysis\Checks\ImageAltCheck;
 use FP\SEO\Analysis\Context;
 use FP\SEO\Analysis\Result;
 use PHPUnit\Framework\TestCase;
+use function Brain\Monkey\Functions\when;
 
 /**
  * Image alt check unit tests.
  */
 final class ImageAltCheckTest extends TestCase {
+        protected function setUp(): void {
+                parent::setUp();
+                Monkey\setUp();
+                when( '__' )->returnArg( 1 );
+                when( 'esc_html__' )->returnArg( 1 );
+        }
+
+        protected function tearDown(): void {
+                Monkey\tearDown();
+                parent::tearDown();
+        }
 	/**
 	 * Ensures full alt coverage passes.
 	 *

--- a/tests/unit/Analysis/InternalLinksCheckTest.php
+++ b/tests/unit/Analysis/InternalLinksCheckTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Internal links check tests.
+ *
+ * @package FP\SEO\Tests
+ */
+
+declare(strict_types=1);
+
+namespace FP\SEO\Tests\Unit\Analysis;
+
+use Brain\Monkey;
+use FP\SEO\Analysis\Checks\InternalLinksCheck;
+use FP\SEO\Analysis\Context;
+use PHPUnit\Framework\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \FP\SEO\Analysis\Checks\InternalLinksCheck
+ */
+class InternalLinksCheckTest extends TestCase {
+        protected function setUp(): void {
+                parent::setUp();
+                Monkey\setUp();
+
+                when( 'home_url' )->justReturn( 'https://example.com/' );
+                when( '__' )->returnArg( 1 );
+                when( 'esc_html__' )->returnArg( 1 );
+                when( 'wp_strip_all_tags' )->alias( 'strip_tags' );
+        }
+
+        protected function tearDown(): void {
+                Monkey\tearDown();
+                parent::tearDown();
+        }
+
+        public function test_run_ignores_external_links(): void {
+                $html    = str_repeat( 'Word ', 200 ) . '<a href="https://example.com/internal">Internal</a>'
+                        . '<a href="https://other.com/page">External</a>';
+                $context = new Context( null, $html, 'Title' );
+
+                $check  = new InternalLinksCheck();
+                $result = $check->run( $context );
+
+                $details = $result->details();
+
+                self::assertSame( 1, $details['links'] );
+                self::assertSame( 'pass', $result->status() );
+        }
+
+        public function test_run_skips_placeholder_links(): void {
+                $html    = str_repeat( 'Word ', 200 ) . '<a href="#">Placeholder</a>';
+                $context = new Context( null, $html, 'Title' );
+
+                $check  = new InternalLinksCheck();
+                $result = $check->run( $context );
+
+                $details = $result->details();
+
+                self::assertSame( 0, $details['links'] );
+                self::assertNotSame( 'pass', $result->status() );
+        }
+}

--- a/tests/unit/Analysis/MetaDescriptionCheckTest.php
+++ b/tests/unit/Analysis/MetaDescriptionCheckTest.php
@@ -9,15 +9,28 @@ declare(strict_types=1);
 
 namespace FP\SEO\Tests\Unit\Analysis;
 
+use Brain\Monkey;
 use FP\SEO\Analysis\Checks\MetaDescriptionCheck;
 use FP\SEO\Analysis\Context;
 use FP\SEO\Analysis\Result;
 use PHPUnit\Framework\TestCase;
+use function Brain\Monkey\Functions\when;
 
 /**
  * Meta description check unit tests.
  */
 final class MetaDescriptionCheckTest extends TestCase {
+        protected function setUp(): void {
+                parent::setUp();
+                Monkey\setUp();
+                when( '__' )->returnArg( 1 );
+                when( 'esc_html__' )->returnArg( 1 );
+        }
+
+        protected function tearDown(): void {
+                Monkey\tearDown();
+                parent::tearDown();
+        }
 	/**
 	 * Ensures valid meta descriptions pass.
 	 *

--- a/tests/unit/Analysis/OgCardsCheckTest.php
+++ b/tests/unit/Analysis/OgCardsCheckTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Open Graph check tests.
+ *
+ * @package FP\SEO\Tests
+ */
+
+declare(strict_types=1);
+
+namespace FP\SEO\Tests\Unit\Analysis;
+
+use Brain\Monkey;
+use FP\SEO\Analysis\Checks\OgCardsCheck;
+use FP\SEO\Analysis\Context;
+use PHPUnit\Framework\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \FP\SEO\Analysis\Checks\OgCardsCheck
+ */
+class OgCardsCheckTest extends TestCase {
+        protected function setUp(): void {
+                parent::setUp();
+                Monkey\setUp();
+                when( '__' )->returnArg( 1 );
+                when( 'esc_html__' )->returnArg( 1 );
+        }
+
+        protected function tearDown(): void {
+                Monkey\tearDown();
+                parent::tearDown();
+        }
+        public function test_run_passes_when_all_required_tags_present(): void {
+                $html = '<meta property="og:title" content="Title" />'
+                        . '<meta property="og:description" content="Description" />'
+                        . '<meta property="og:type" content="article" />'
+                        . '<meta property="og:url" content="https://example.com/" />'
+                        . '<meta property="og:image" content="https://example.com/image.jpg" />';
+
+                $context = new Context( null, '<head>' . $html . '</head>' );
+                $check   = new OgCardsCheck();
+                $result  = $check->run( $context );
+
+                self::assertSame( 'pass', $result->status() );
+        }
+
+        public function test_run_uses_secure_image_fallback(): void {
+                $html = '<meta property="og:title" content="Title" />'
+                        . '<meta property="og:description" content="Description" />'
+                        . '<meta property="og:type" content="article" />'
+                        . '<meta property="og:url" content="https://example.com/" />'
+                        . '<meta property="og:image:secure_url" content="https://example.com/image-secure.jpg" />';
+
+                $context = new Context( null, '<head>' . $html . '</head>' );
+                $check   = new OgCardsCheck();
+                $result  = $check->run( $context );
+
+                self::assertSame( 'pass', $result->status() );
+        }
+
+        public function test_run_reports_missing_image(): void {
+                $html = '<meta property="og:title" content="Title" />'
+                        . '<meta property="og:description" content="Description" />'
+                        . '<meta property="og:type" content="article" />'
+                        . '<meta property="og:url" content="https://example.com/" />';
+
+                $context = new Context( null, '<head>' . $html . '</head>' );
+                $check   = new OgCardsCheck();
+                $result  = $check->run( $context );
+
+                self::assertContains( 'og:image', $result->details()['missing'] );
+        }
+}

--- a/tests/unit/Analysis/TitleLengthCheckTest.php
+++ b/tests/unit/Analysis/TitleLengthCheckTest.php
@@ -9,15 +9,28 @@ declare(strict_types=1);
 
 namespace FP\SEO\Tests\Unit\Analysis;
 
+use Brain\Monkey;
 use FP\SEO\Analysis\Checks\TitleLengthCheck;
 use FP\SEO\Analysis\Context;
 use FP\SEO\Analysis\Result;
 use PHPUnit\Framework\TestCase;
+use function Brain\Monkey\Functions\when;
 
 /**
  * Title length check unit tests.
  */
 final class TitleLengthCheckTest extends TestCase {
+        protected function setUp(): void {
+                parent::setUp();
+                Monkey\setUp();
+                when( '__' )->returnArg( 1 );
+                when( 'esc_html__' )->returnArg( 1 );
+        }
+
+        protected function tearDown(): void {
+                Monkey\tearDown();
+                parent::tearDown();
+        }
 	/**
 	 * Ensures ideal title lengths pass.
 	 *

--- a/tests/unit/Analysis/TwitterCardsCheckTest.php
+++ b/tests/unit/Analysis/TwitterCardsCheckTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Twitter cards check tests.
+ *
+ * @package FP\SEO\Tests
+ */
+
+declare(strict_types=1);
+
+namespace FP\SEO\Tests\Unit\Analysis;
+
+use Brain\Monkey;
+use FP\SEO\Analysis\Checks\TwitterCardsCheck;
+use FP\SEO\Analysis\Context;
+use PHPUnit\Framework\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \FP\SEO\Analysis\Checks\TwitterCardsCheck
+ */
+class TwitterCardsCheckTest extends TestCase {
+        protected function setUp(): void {
+                parent::setUp();
+                Monkey\setUp();
+                when( '__' )->returnArg( 1 );
+                when( 'esc_html__' )->returnArg( 1 );
+        }
+
+        protected function tearDown(): void {
+                Monkey\tearDown();
+                parent::tearDown();
+        }
+        public function test_run_passes_with_all_tags_present(): void {
+                $html = '<meta name="twitter:card" content="summary_large_image" />'
+                        . '<meta name="twitter:title" content="Title" />'
+                        . '<meta name="twitter:description" content="Description" />'
+                        . '<meta name="twitter:image" content="https://example.com/image.jpg" />';
+
+                $context = new Context( null, '<head>' . $html . '</head>' );
+                $check   = new TwitterCardsCheck();
+                $result  = $check->run( $context );
+
+                self::assertSame( 'pass', $result->status() );
+        }
+
+        public function test_run_accepts_image_src_fallback(): void {
+                $html = '<meta name="twitter:card" content="summary" />'
+                        . '<meta name="twitter:title" content="Title" />'
+                        . '<meta name="twitter:description" content="Description" />'
+                        . '<meta name="twitter:image:src" content="https://example.com/image.jpg" />';
+
+                $context = new Context( null, '<head>' . $html . '</head>' );
+                $check   = new TwitterCardsCheck();
+                $result  = $check->run( $context );
+
+                self::assertSame( 'pass', $result->status() );
+        }
+
+        public function test_run_reports_missing_image(): void {
+                $html = '<meta name="twitter:card" content="summary" />'
+                        . '<meta name="twitter:title" content="Title" />'
+                        . '<meta name="twitter:description" content="Description" />';
+
+                $context = new Context( null, '<head>' . $html . '</head>' );
+                $check   = new TwitterCardsCheck();
+                $result  = $check->run( $context );
+
+                self::assertContains( 'twitter:image', $result->details()['missing'] );
+        }
+}

--- a/tests/unit/Editor/MetaboxTest.php
+++ b/tests/unit/Editor/MetaboxTest.php
@@ -44,16 +44,21 @@ class MetaboxTest extends TestCase {
 		$this->updated_meta = array();
 		$this->deleted_meta = array();
 
-		when( 'sanitize_text_field' )->alias(
-			static function ( $value ) {
-				return $value;
-			}
-		);
+                when( 'sanitize_text_field' )->alias(
+                        static function ( $value ) {
+                                return $value;
+                        }
+                );
+                when( 'esc_url_raw' )->alias(
+                        static function ( $value ) {
+                                return $value;
+                        }
+                );
 
-		when( 'wp_unslash' )->alias(
-			static function ( $value ) {
-				return $value;
-			}
+                when( 'wp_unslash' )->alias(
+                        static function ( $value ) {
+                                return $value;
+                        }
 		);
 
 		when( 'wp_verify_nonce' )->justReturn( true );

--- a/tests/unit/OptionsTest.php
+++ b/tests/unit/OptionsTest.php
@@ -139,11 +139,11 @@ class OptionsTest extends TestCase {
 		/**
 		 * Ensures scoring weights are normalized and warn on invalid input.
 		 */
-	public function test_sanitize_normalizes_scoring_weights(): void {
-			$captured = array();
-			when( 'add_settings_error' )->alias(
-				static function ( $setting, $code, $message, $type = 'error' ) use ( &$captured ): void {
-							$captured[] = array(
+        public function test_sanitize_normalizes_scoring_weights(): void {
+                        $captured = array();
+                        when( 'add_settings_error' )->alias(
+                                static function ( $setting, $code, $message, $type = 'error' ) use ( &$captured ): void {
+                                                        $captured[] = array(
 								'setting' => $setting,
 								'code'    => $code,
 								'message' => $message,
@@ -170,8 +170,23 @@ class OptionsTest extends TestCase {
 			self::assertSame( 0.0, $sanitized['scoring']['weights']['h1_presence'] );
 			self::assertSame( 5.0, $sanitized['scoring']['weights']['internal_links'] );
 
-			$notice = end( $captured );
-			self::assertSame( 'fp_seo_perf_scoring_weights', $notice['code'] );
-			self::assertSame( 'warning', $notice['type'] );
-	}
+                        $notice = end( $captured );
+                        self::assertSame( 'fp_seo_perf_scoring_weights', $notice['code'] );
+                        self::assertSame( 'warning', $notice['type'] );
+        }
+
+        /**
+         * Ensures unsupported languages fallback to the default option.
+         */
+        public function test_sanitize_resets_unsupported_language(): void {
+                $sanitized = Options::sanitize(
+                        array(
+                                'general' => array(
+                                        'language' => 'pt',
+                                ),
+                        )
+                );
+
+                self::assertSame( Options::get_defaults()['general']['language'], $sanitized['general']['language'] );
+        }
 }


### PR DESCRIPTION
## Summary
- validate HTTP response codes in the Site Health SEO check and escape the admin badge tooltip while tightening canonical sanitization
- align heuristics configuration, internal link detection, and social metadata checks with the new options (including og:image/twitter:image requirements)
- preserve heading document order, cap cached bulk results, and extend the automated test suite for the new behaviours

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68dcd7b60fd8832fb5365776db04aa04