### PR TITLE
Decode percent-encoded hosts before PSI requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,13 @@
         "yoast/phpunit-polyfills": "^2.0"
     },
     "scripts": {
-        "test": "phpunit",
+        "test": "vendor/bin/phpunit",
         "lint": [
             "@phpcs"
         ],
-        "phpcs": "phpcs",
-        "phpstan": "phpstan analyse",
-        "rector": "rector process"
+        "phpcs": "vendor/bin/phpcs",
+        "phpstan": "vendor/bin/phpstan analyse",
+        "rector": "vendor/bin/rector process"
     },
     "config": {
         "allow-plugins": {

--- a/src/Utils/UrlNormalizer.php
+++ b/src/Utils/UrlNormalizer.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * URL normalization helpers.
+ *
+ * @package FP\SEO
+ */
+
+declare(strict_types=1);
+
+namespace FP\SEO\Utils;
+
+use function ctype_xdigit;
+use function html_entity_decode;
+use function is_array;
+use function rawurldecode;
+use function str_ireplace;
+use function str_replace;
+use function strpos;
+use function trim;
+use function strlen;
+use function wp_parse_url;
+
+use const ENT_HTML5;
+use const ENT_QUOTES;
+
+/**
+ * Provides helpers for normalizing user supplied URLs before outbound requests.
+ */
+class UrlNormalizer {
+
+        /**
+         * Reserved encodings that should remain percent-encoded within query strings.
+         *
+         * @var string[]
+         */
+        private const RESERVED_QUERY_ENCODINGS = array(
+                '%26', // &
+                '%3D', // =
+                '%23', // #
+                '%3A', // :
+                '%2F', // /
+                '%3F', // ?
+                '%25', // %
+                '%2B', // +
+        );
+
+        /**
+         * Reserved encodings that should remain percent-encoded within URL paths.
+         *
+         * @var string[]
+         */
+        private const RESERVED_PATH_ENCODINGS = array(
+                '%2F', // /
+                '%3F', // ?
+                '%23', // #
+                '%3D', // =
+                '%25', // %
+        );
+
+        /**
+         * Reserved encodings that should remain percent-encoded within URL fragments.
+         *
+         * @var string[]
+         */
+        private const RESERVED_FRAGMENT_ENCODINGS = array(
+                '%2F', // /
+                '%3F', // ?
+                '%23', // #
+                '%3D', // =
+                '%25', // %
+        );
+
+        /**
+         * Reserved encodings that should remain percent-encoded within credentials.
+         *
+         * @var string[]
+         */
+        private const RESERVED_CREDENTIAL_ENCODINGS = array(
+                '%3A', // :
+                '%40', // @
+                '%2F', // /
+                '%3F', // ?
+                '%23', // #
+                '%25', // %
+        );
+
+        /**
+         * Decodes HTML entities and safe percent-encodings while preserving reserved characters.
+         *
+         * @param string $url Raw URL that may be HTML-entity encoded or percent-encoded.
+         */
+        public static function normalize( string $url ): string {
+                $decoded = html_entity_decode( trim( $url ), ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+
+                $parts = wp_parse_url( $decoded );
+
+                if ( ! is_array( $parts ) ) {
+                        return rawurldecode( $decoded );
+                }
+
+                if ( ! isset( $parts['scheme'] ) && isset( $parts['path'] ) ) {
+                        $decoded_once = rawurldecode( $decoded );
+
+                        if ( $decoded_once !== $decoded ) {
+                                $reparsed = wp_parse_url( $decoded_once );
+
+                                if ( is_array( $reparsed ) && isset( $reparsed['scheme'] ) ) {
+                                        $decoded = $decoded_once;
+                                        $parts   = $reparsed;
+                                }
+                        }
+                }
+
+                if ( isset( $parts['user'] ) && '' !== $parts['user'] ) {
+                        $parts['user'] = self::decode_component_preserving( (string) $parts['user'], self::RESERVED_CREDENTIAL_ENCODINGS );
+                }
+
+                if ( isset( $parts['pass'] ) && '' !== $parts['pass'] ) {
+                        $parts['pass'] = self::decode_component_preserving( (string) $parts['pass'], self::RESERVED_CREDENTIAL_ENCODINGS );
+                }
+
+                if ( isset( $parts['host'] ) && '' !== $parts['host'] ) {
+                        $parts['host'] = self::decode_component_preserving( (string) $parts['host'], array() );
+                }
+
+                if ( isset( $parts['path'] ) && '' !== $parts['path'] ) {
+                        $parts['path'] = self::decode_component_preserving( (string) $parts['path'], self::RESERVED_PATH_ENCODINGS );
+                }
+
+                if ( isset( $parts['query'] ) && '' !== $parts['query'] ) {
+                        $parts['query'] = self::decode_component_preserving(
+                                (string) $parts['query'],
+                                self::RESERVED_QUERY_ENCODINGS,
+                                array( '%26', '%3D' )
+                        );
+                }
+
+                if ( isset( $parts['fragment'] ) && '' !== $parts['fragment'] ) {
+                        $parts['fragment'] = self::decode_component_preserving( (string) $parts['fragment'], self::RESERVED_FRAGMENT_ENCODINGS );
+                }
+
+                return self::build_url_from_parts( $parts );
+        }
+
+        /**
+         * Reconstructs a URL string from parse_url parts.
+         *
+         * @param array<string, mixed> $parts Parsed URL parts.
+         */
+        private static function build_url_from_parts( array $parts ): string {
+                $raw_scheme = isset( $parts['scheme'] ) ? (string) $parts['scheme'] : '';
+                $user       = isset( $parts['user'] ) ? (string) $parts['user'] : '';
+                $pass       = isset( $parts['pass'] ) ? (string) $parts['pass'] : '';
+                $host       = (string) ( $parts['host'] ?? '' );
+                $port       = isset( $parts['port'] ) ? ':' . $parts['port'] : '';
+                $path       = (string) ( $parts['path'] ?? '' );
+                $query      = isset( $parts['query'] ) && '' !== $parts['query'] ? '?' . $parts['query'] : '';
+                $fragment   = isset( $parts['fragment'] ) && '' !== $parts['fragment'] ? '#' . $parts['fragment'] : '';
+
+                $auth = '';
+                if ( '' !== $user ) {
+                        $auth = $user;
+                        if ( '' !== $pass ) {
+                                $auth .= ':' . $pass;
+                        }
+                        $auth .= '@';
+                }
+
+                $authority = '';
+                if ( '' !== $host || '' !== $auth ) {
+                        $authority = $auth . $host . $port;
+                }
+
+                $prefix = '';
+                if ( '' !== $raw_scheme ) {
+                        $prefix = $raw_scheme;
+
+                        if ( '' !== $authority || ( '' !== $path && 0 === strpos( $path, '/' ) ) ) {
+                                $prefix .= '://';
+                        } else {
+                                $prefix .= ':';
+                        }
+                } elseif ( '' !== $authority ) {
+                        $prefix = '//';
+                }
+
+                if ( '' === $prefix && '' === $authority ) {
+                        return $path . $query . $fragment;
+                }
+
+                return $prefix . $authority . $path . $query . $fragment;
+        }
+
+        /**
+         * Decodes a URL component while preserving a set of reserved encodings.
+         *
+         * @param string   $component           Raw component value.
+         * @param string[] $reserved_encodings Encoded sequences to keep untouched.
+         */
+        /**
+         * Decodes safe percent-encoded sequences while preserving reserved encodings.
+         *
+         * @param string   $component        Raw component value.
+         * @param string[] $reserved_encodings Encoded sequences that must remain percent-encoded.
+         * @param string[] $preserve_double Encodings that should not collapse when double-encoded.
+         */
+        private static function decode_component_preserving( string $component, array $reserved_encodings, array $preserve_double = array() ): string {
+                if ( '' === $component ) {
+                        return $component;
+                }
+
+                $length       = strlen( $component );
+                $result       = '';
+                $reserved_set = array();
+                $preserve_double_set = array();
+
+                foreach ( $reserved_encodings as $encoded ) {
+                        $reserved_set[ strtoupper( $encoded ) ] = true;
+                }
+
+                foreach ( $preserve_double as $encoded ) {
+                        $preserve_double_set[ strtoupper( $encoded ) ] = true;
+                }
+
+                $changed = false;
+
+                for ( $i = 0; $i < $length; ) {
+                        if (
+                                '%' === $component[ $i ]
+                                && ( $i + 2 ) < $length
+                                && ctype_xdigit( $component[ $i + 1 ] )
+                                && ctype_xdigit( $component[ $i + 2 ] )
+                        ) {
+                                $encoded = '%' . strtoupper( $component[ $i + 1 ] . $component[ $i + 2 ] );
+
+                                if (
+                                        '%25' === $encoded
+                                        && ( $i + 4 ) < $length
+                                        && ctype_xdigit( $component[ $i + 3 ] )
+                                        && ctype_xdigit( $component[ $i + 4 ] )
+                                ) {
+                                        $next_encoded = '%' . strtoupper( $component[ $i + 3 ] . $component[ $i + 4 ] );
+
+                                        if ( isset( $preserve_double_set[ $next_encoded ] ) ) {
+                                                $result .= '%25';
+                                                $i      += 3;
+                                                continue;
+                                        }
+
+                                        $result .= $next_encoded;
+                                        $i      += 5;
+                                        $changed = true;
+                                        continue;
+                                }
+
+                                if ( isset( $reserved_set[ $encoded ] ) ) {
+                                        $result .= $encoded;
+                                        $i      += 3;
+                                        continue;
+                                }
+
+                                $run       = '';
+                                $run_start = $i;
+
+                                while (
+                                        ( $i + 2 ) < $length
+                                        && '%' === $component[ $i ]
+                                        && ctype_xdigit( $component[ $i + 1 ] )
+                                        && ctype_xdigit( $component[ $i + 2 ] )
+                                ) {
+                                        $candidate = '%' . strtoupper( $component[ $i + 1 ] . $component[ $i + 2 ] );
+
+                                        if (
+                                                '%25' === $candidate
+                                                && ( $i + 4 ) < $length
+                                                && ctype_xdigit( $component[ $i + 3 ] )
+                                                && ctype_xdigit( $component[ $i + 4 ] )
+                                        ) {
+                                                $next_encoded = '%' . strtoupper( $component[ $i + 3 ] . $component[ $i + 4 ] );
+
+                                                if ( isset( $preserve_double_set[ $next_encoded ] ) ) {
+                                                        break;
+                                                }
+
+                                                break;
+                                        }
+
+                                        if ( isset( $reserved_set[ $candidate ] ) ) {
+                                                break;
+                                        }
+
+                                        $run .= $candidate;
+                                        $i   += 3;
+                                }
+
+                                if ( '' === $run ) {
+                                        $result .= $component[ $run_start ];
+                                        $i       = $run_start + 1;
+                                        continue;
+                                }
+
+                                $decoded = rawurldecode( $run );
+
+                                if ( $decoded !== $run ) {
+                                        $changed = true;
+                                }
+
+                                $result .= $decoded;
+                                continue;
+                        }
+
+                        $result .= $component[ $i ];
+                        $i++;
+                }
+
+                if ( $changed ) {
+                        return self::decode_component_preserving( $result, $reserved_encodings, $preserve_double );
+                }
+
+                return $result;
+        }
+}

--- a/tests/unit/SeoHealthTest.php
+++ b/tests/unit/SeoHealthTest.php
@@ -1,0 +1,410 @@
+<?php
+/**
+ * Site Health integration tests.
+ *
+ * @package FP\SEO\Tests
+ */
+
+declare(strict_types=1);
+
+namespace FP\SEO\Tests\Unit;
+
+use Brain\Monkey;
+use FP\SEO\SiteHealth\SeoHealth;
+use PHPUnit\Framework\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \FP\SEO\SiteHealth\SeoHealth
+ */
+class SeoHealthTest extends TestCase
+{
+        /**
+         * Bootstraps Brain Monkey.
+         */
+        protected function setUp(): void
+        {
+                parent::setUp();
+                Monkey\setUp();
+
+                when( '__' )->returnArg( 1 );
+                when( 'esc_html__' )->returnArg( 1 );
+                when( 'esc_html' )->returnArg( 1 );
+                when( 'esc_url' )->returnArg( 1 );
+                when( 'admin_url' )->returnArg( 1 );
+                when( 'sanitize_text_field' )->returnArg( 1 );
+                when( 'sanitize_key' )->returnArg( 1 );
+                when( 'add_settings_error' )->justReturn( null );
+                when( 'wp_strip_all_tags' )->alias( 'strip_tags' );
+                when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+                when( 'wp_remote_retrieve_body' )->alias(
+                        static function ( $response ) {
+                                return is_array( $response ) ? ( $response['body'] ?? '' ) : '';
+                        }
+                );
+                when( 'wp_parse_url' )->alias(
+                        static function ( $url ) {
+                                return parse_url( (string) $url );
+                        }
+                );
+        }
+
+        /**
+         * Tears down Brain Monkey.
+         */
+        protected function tearDown(): void
+        {
+                Monkey\tearDown();
+                parent::tearDown();
+        }
+
+        /**
+         * Ensures the PSI endpoint receives an unencoded homepage URL.
+         */
+        public function test_run_performance_test_uses_raw_home_url(): void
+        {
+                when( 'get_option' )->alias(
+                        static function ( $option, $default = false ) {
+                                if ( 'fp_seo_perf_options' === $option ) {
+                                        return array(
+                                                'performance' => array(
+                                                        'enable_psi'  => true,
+                                                        'psi_api_key' => 'api-key',
+                                                ),
+                                        );
+                                }
+
+                                return $default;
+                        }
+                );
+
+                when( 'home_url' )->justReturn( 'https://example.com/' );
+                when( 'is_wp_error' )->justReturn( false );
+
+                $captured_args = null;
+                when( 'add_query_arg' )->alias(
+                        static function ( $args, $url ) use ( &$captured_args ) {
+                                $captured_args = $args;
+
+                                return $url . '?' . http_build_query( $args );
+                        }
+                );
+
+                when( 'wp_remote_get' )->alias(
+                        static function () {
+                                return array();
+                        }
+                );
+
+                when( 'wp_remote_retrieve_body' )->alias(
+                        static function () {
+                                return json_encode(
+                                        array(
+                                                'lighthouseResult' => array(
+                                                        'categories' => array(
+                                                                'performance' => array(
+                                                                        'score' => 0.85,
+                                                                ),
+                                                        ),
+                                                ),
+                                        )
+                                );
+                        }
+                );
+
+                $health = new SeoHealth();
+                $result = $health->run_performance_test();
+
+                self::assertIsArray( $captured_args );
+                self::assertArrayHasKey( 'url', $captured_args );
+                self::assertSame( 'https://example.com/', $captured_args['url'] );
+                self::assertSame( 'good', $result['status'] );
+        }
+
+        /**
+         * Homepage SEO requests should limit redirect chains to avoid long waits.
+         */
+        public function test_run_seo_test_limits_redirects(): void
+        {
+                when( 'home_url' )->justReturn( 'https://example.com/' );
+                when( 'get_option' )->alias(
+                        static function ( $option, $default = false ) {
+                                if ( 'blog_public' === $option ) {
+                                        return '1';
+                                }
+
+                                return $default;
+                        }
+                );
+                when( 'is_wp_error' )->justReturn( false );
+
+                expect( 'wp_remote_get' )
+                        ->once()
+                        ->with(
+                                'https://example.com/',
+                                array(
+                                        'timeout'     => 10,
+                                        'headers'     => array(),
+                                        'redirection' => 3,
+                                )
+                        )
+                        ->andReturn(
+                                array(
+                                        'body' => '<html><head><title>Welcome</title><meta name="description" content="Site" /><link rel="canonical" href="https://example.com/" /></head><body></body></html>',
+                                )
+                        );
+
+                $health = new SeoHealth();
+                $result = $health->run_seo_test();
+
+                self::assertSame( 'good', $result['status'] );
+        }
+
+        /**
+         * Encoded home URLs should decode safe characters before building the PSI endpoint.
+         */
+        public function test_run_performance_test_decodes_percent_encoded_home_url(): void
+        {
+                when( 'get_option' )->alias(
+                        static function ( $option, $default = false ) {
+                                if ( 'fp_seo_perf_options' === $option ) {
+                                        return array(
+                                                'performance' => array(
+                                                        'enable_psi'  => true,
+                                                        'psi_api_key' => 'api-key',
+                                                ),
+                                        );
+                                }
+
+                                return $default;
+                        }
+                );
+
+                when( 'home_url' )->justReturn( 'https://example.com/about%20us/' );
+                when( 'is_wp_error' )->justReturn( false );
+
+                $captured_args = null;
+                when( 'add_query_arg' )->alias(
+                        static function ( $args, $url ) use ( &$captured_args ) {
+                                $captured_args = $args;
+
+                                return $url . '?' . http_build_query( $args );
+                        }
+                );
+
+                when( 'wp_remote_get' )->alias(
+                        static function () {
+                                return array();
+                        }
+                );
+
+                when( 'wp_remote_retrieve_body' )->alias(
+                        static function () {
+                                return json_encode(
+                                        array(
+                                                'lighthouseResult' => array(
+                                                        'categories' => array(
+                                                                'performance' => array(
+                                                                        'score' => 0.9,
+                                                                ),
+                                                        ),
+                                                ),
+                                        )
+                                );
+                        }
+                );
+
+                $health = new SeoHealth();
+                $result = $health->run_performance_test();
+
+                self::assertIsArray( $captured_args );
+                self::assertArrayHasKey( 'url', $captured_args );
+                self::assertSame( 'https://example.com/about us/', $captured_args['url'] );
+                self::assertSame( 'good', $result['status'] );
+        }
+
+        public function test_run_performance_test_preserves_plus_sign_query_encodings(): void
+        {
+                when( 'get_option' )->alias(
+                        static function ( $option, $default = false ) {
+                                if ( 'fp_seo_perf_options' === $option ) {
+                                        return array(
+                                                'performance' => array(
+                                                        'enable_psi'  => true,
+                                                        'psi_api_key' => 'api-key',
+                                                ),
+                                        );
+                                }
+
+                                return $default;
+                        }
+                );
+
+                when( 'home_url' )->justReturn( 'https://example.com/?q=cat%2Bdog' );
+                when( 'is_wp_error' )->justReturn( false );
+
+                $captured_args = null;
+                when( 'add_query_arg' )->alias(
+                        static function ( $args, $url ) use ( &$captured_args ) {
+                                $captured_args = $args;
+
+                                return $url . '?' . http_build_query( $args );
+                        }
+                );
+
+                when( 'wp_remote_get' )->alias(
+                        static function () {
+                                return array();
+                        }
+                );
+
+                when( 'wp_remote_retrieve_body' )->alias(
+                        static function () {
+                                return json_encode(
+                                        array(
+                                                'lighthouseResult' => array(
+                                                        'categories' => array(
+                                                                'performance' => array(
+                                                                        'score' => 0.9,
+                                                                ),
+                                                        ),
+                                                ),
+                                        )
+                                );
+                        }
+                );
+
+                $health = new SeoHealth();
+                $result = $health->run_performance_test();
+
+                self::assertIsArray( $captured_args );
+                self::assertArrayHasKey( 'url', $captured_args );
+                self::assertSame( 'https://example.com/?q=cat%2Bdog', $captured_args['url'] );
+                self::assertSame( 'good', $result['status'] );
+        }
+
+        /**
+         * HTML entity encoded home URLs should be decoded before invoking PSI.
+         */
+        public function test_run_performance_test_decodes_html_entities_in_home_url(): void
+        {
+                when( 'get_option' )->alias(
+                        static function ( $option, $default = false ) {
+                                if ( 'fp_seo_perf_options' === $option ) {
+                                        return array(
+                                                'performance' => array(
+                                                        'enable_psi'  => true,
+                                                        'psi_api_key' => 'api-key',
+                                                ),
+                                        );
+                                }
+
+                                return $default;
+                        }
+                );
+
+                when( 'home_url' )->justReturn( 'https://example.com/?ref=summer&amp;utm=promo' );
+                when( 'is_wp_error' )->justReturn( false );
+
+                $captured_args = null;
+                when( 'add_query_arg' )->alias(
+                        static function ( $args, $url ) use ( &$captured_args ) {
+                                $captured_args = $args;
+
+                                return $url . '?' . http_build_query( $args );
+                        }
+                );
+
+                when( 'wp_remote_get' )->alias(
+                        static function () {
+                                return array();
+                        }
+                );
+
+                when( 'wp_remote_retrieve_body' )->alias(
+                        static function () {
+                                return json_encode(
+                                        array(
+                                                'lighthouseResult' => array(
+                                                        'categories' => array(
+                                                                'performance' => array(
+                                                                        'score' => 0.93,
+                                                                ),
+                                                        ),
+                                                ),
+                                        )
+                                );
+                        }
+                );
+
+                $health = new SeoHealth();
+                $result = $health->run_performance_test();
+
+                self::assertIsArray( $captured_args );
+                self::assertSame( 'https://example.com/?ref=summer&utm=promo', $captured_args['url'] );
+                self::assertSame( 'good', $result['status'] );
+        }
+
+        /**
+         * PSI API errors should be reported with the returned message.
+         */
+        public function test_run_performance_test_surfaces_api_error_message(): void
+        {
+                when( 'get_option' )->alias(
+                        static function ( $option, $default = false ) {
+                                if ( 'fp_seo_perf_options' === $option ) {
+                                        return array(
+                                                'performance' => array(
+                                                        'enable_psi'  => true,
+                                                        'psi_api_key' => 'api-key',
+                                                ),
+                                        );
+                                }
+
+                                return $default;
+                        }
+                );
+
+                when( 'home_url' )->justReturn( 'https://example.com/' );
+                when( 'is_wp_error' )->justReturn( false );
+
+                $captured_args = null;
+                when( 'add_query_arg' )->alias(
+                        static function ( $args, $url ) use ( &$captured_args ) {
+                                $captured_args = $args;
+
+                                return $url . '?' . http_build_query( $args );
+                        }
+                );
+
+                when( 'wp_remote_get' )->alias(
+                        static function () {
+                                return array(
+                                        'body' => json_encode(
+                                                array(
+                                                        'error' => array(
+                                                                'code'    => 400,
+                                                                'message' => 'API key has been revoked.',
+                                                                'errors'  => array(
+                                                                        array(
+                                                                                'message' => 'Please generate a new API key.',
+                                                                        ),
+                                                                ),
+                                                        ),
+                                                )
+                                        ),
+                                );
+                        }
+                );
+
+                $health = new SeoHealth();
+                $result = $health->run_performance_test();
+
+                self::assertIsArray( $captured_args );
+                self::assertSame( 'https://example.com/', $captured_args['url'] );
+                self::assertSame( 'recommended', $result['status'] );
+                self::assertSame( 'PageSpeed Insights API returned an error', $result['label'] );
+                self::assertStringContainsString( 'API key has been revoked.', $result['description'] );
+        }
+}

--- a/tests/unit/SiteHealth/SeoHealthTest.php
+++ b/tests/unit/SiteHealth/SeoHealthTest.php
@@ -46,18 +46,23 @@ class SeoHealthTest extends TestCase {
 								return 'http://example.com/wp-admin/' . ltrim( $path, '/' );
 					}
 				);
-				when( 'home_url' )->alias(
-					static function ( string $path = '', string $scheme = 'http' ): string {
-								unset( $scheme );
+                                when( 'home_url' )->alias(
+                                        static function ( string $path = '', string $scheme = 'http' ): string {
+                                                                unset( $scheme );
 
-								return 'https://example.com' . $path;
-					}
-				);
-				when( 'add_query_arg' )->alias(
-					static function ( array $args, string $url ): string {
-								return $url . '?' . http_build_query( $args );
-					}
-				);
+                                                                return 'https://example.com' . $path;
+                                        }
+                                );
+                                when( 'wp_parse_url' )->alias(
+                                        static function ( $url ) {
+                                                return parse_url( (string) $url );
+                                        }
+                                );
+                                when( 'add_query_arg' )->alias(
+                                        static function ( array $args, string $url ): string {
+                                                                return $url . '?' . http_build_query( $args );
+                                        }
+                                );
 				when( 'get_option' )->alias(
 					static function ( string $option, $default_value = false ) {
 						if ( 'blog_public' === $option ) {
@@ -76,6 +81,8 @@ class SeoHealthTest extends TestCase {
 								return false;
 					}
 				);
+                when( 'wp_json_encode' )->alias( 'json_encode' );
+
                 when( 'wp_remote_retrieve_body' )->alias(
                         static function ( $response ) {
                                 return is_array( $response ) ? ( $response['body'] ?? '' ) : '';
@@ -161,14 +168,305 @@ class SeoHealthTest extends TestCase {
 	/**
 	 * Confirms performance test prompts for API key when PSI disabled.
 	 */
-	public function test_run_performance_test_prompts_for_api_key(): void {
-		when( 'wp_remote_get' )->justReturn( array() );
+        public function test_run_performance_test_prompts_for_api_key(): void {
+                when( 'wp_remote_get' )->justReturn( array() );
 
-		$health = new SeoHealth();
-		$result = $health->run_performance_test();
+                $health = new SeoHealth();
+                $result = $health->run_performance_test();
 
-		self::assertSame( 'recommended', $result['status'] );
-		self::assertSame( 'PageSpeed Insights API key not configured', $result['label'] );
-		self::assertNotEmpty( $result['actions'] );
-	}
+                self::assertSame( 'recommended', $result['status'] );
+                self::assertSame( 'PageSpeed Insights API key not configured', $result['label'] );
+                self::assertNotEmpty( $result['actions'] );
+        }
+
+        /**
+         * Nested encoded query values should stay encoded when Site Health requests PSI.
+         */
+        public function test_run_performance_test_preserves_nested_query_encoding(): void {
+                $nested_url = 'https://example.com/?redirect=https%3A%2F%2Fdest.test%2F%3Fa%3Db%2526c%253Dd';
+
+                when( 'get_option' )->alias(
+                        static function ( string $option, $default_value = false ) {
+                                if ( 'blog_public' === $option ) {
+                                        return '1';
+                                }
+
+                                if ( Options::OPTION_KEY === $option ) {
+                                        return array(
+                                                'performance' => array(
+                                                        'enable_psi'  => true,
+                                                        'psi_api_key' => 'abc123',
+                                                ),
+                                        );
+                                }
+
+                                return $default_value;
+                        }
+                );
+
+                when( 'home_url' )->justReturn( $nested_url );
+
+                $captured_args = null;
+                when( 'add_query_arg' )->alias(
+                        static function ( array $args, string $url ) use ( &$captured_args ): string {
+                                $captured_args = $args;
+
+                                return $url . '?' . http_build_query( $args );
+                        }
+                );
+
+                when( 'wp_remote_get' )->justReturn(
+                        array(
+                                'body' => wp_json_encode(
+                                        array(
+                                                'lighthouseResult' => array(
+                                                        'categories' => array(
+                                                                'performance' => array(
+                                                                        'score' => 0.95,
+                                                                ),
+                                                        ),
+                                                ),
+                                        )
+                                ),
+                        )
+                );
+
+                $health = new SeoHealth();
+                $result = $health->run_performance_test();
+
+                self::assertIsArray( $captured_args );
+                self::assertArrayHasKey( 'url', $captured_args );
+                self::assertSame( $nested_url, $captured_args['url'] );
+                self::assertSame( 'good', $result['status'] );
+        }
+
+        public function test_run_performance_test_preserves_plus_sign_query_encodings(): void {
+                $home_url = 'https://example.com/?q=cat%2Bdog';
+
+                when( 'get_option' )->alias(
+                        static function ( string $option, $default_value = false ) {
+                                if ( 'blog_public' === $option ) {
+                                        return '1';
+                                }
+
+                                if ( Options::OPTION_KEY === $option ) {
+                                        return array(
+                                                'performance' => array(
+                                                        'enable_psi'  => true,
+                                                        'psi_api_key' => 'abc123',
+                                                ),
+                                        );
+                                }
+
+                                return $default_value;
+                        }
+                );
+
+                when( 'home_url' )->justReturn( $home_url );
+
+                $captured_args = null;
+                when( 'add_query_arg' )->alias(
+                        static function ( array $args, string $url ) use ( &$captured_args ): string {
+                                $captured_args = $args;
+
+                                return $url . '?' . http_build_query( $args );
+                        }
+                );
+
+                when( 'wp_remote_get' )->justReturn(
+                        array(
+                                'body' => wp_json_encode(
+                                        array(
+                                                'lighthouseResult' => array(
+                                                        'categories' => array(
+                                                                'performance' => array(
+                                                                        'score' => 0.95,
+                                                                ),
+                                                        ),
+                                                ),
+                                        )
+                                ),
+                        )
+                );
+
+                $health = new SeoHealth();
+                $result = $health->run_performance_test();
+
+                self::assertIsArray( $captured_args );
+                self::assertArrayHasKey( 'url', $captured_args );
+                self::assertSame( $home_url, $captured_args['url'] );
+                self::assertSame( 'good', $result['status'] );
+        }
+
+        public function test_run_performance_test_decodes_percent_encoded_host(): void {
+                $home_url     = 'https://%65xample.com/?id=42';
+                $expected_url = 'https://example.com/?id=42';
+
+                when( 'get_option' )->alias(
+                        static function ( string $option, $default_value = false ) {
+                                if ( 'blog_public' === $option ) {
+                                        return '1';
+                                }
+
+                                if ( Options::OPTION_KEY === $option ) {
+                                        return array(
+                                                'performance' => array(
+                                                        'enable_psi'  => true,
+                                                        'psi_api_key' => 'abc123',
+                                                ),
+                                        );
+                                }
+
+                                return $default_value;
+                        }
+                );
+
+                when( 'home_url' )->justReturn( $home_url );
+
+                $captured_args = null;
+                when( 'add_query_arg' )->alias(
+                        static function ( array $args, string $url ) use ( &$captured_args ): string {
+                                $captured_args = $args;
+
+                                return $url . '?' . http_build_query( $args );
+                        }
+                );
+
+                when( 'wp_remote_get' )->justReturn(
+                        array(
+                                'body' => wp_json_encode(
+                                        array(
+                                                'lighthouseResult' => array(
+                                                        'categories' => array(
+                                                                'performance' => array(
+                                                                        'score' => 0.94,
+                                                                ),
+                                                        ),
+                                                ),
+                                        )
+                                ),
+                        )
+                );
+
+                $health = new SeoHealth();
+                $result = $health->run_performance_test();
+
+                self::assertIsArray( $captured_args );
+                self::assertArrayHasKey( 'url', $captured_args );
+                self::assertSame( $expected_url, $captured_args['url'] );
+                self::assertSame( 'good', $result['status'] );
+        }
+
+        public function test_run_performance_test_decodes_fully_encoded_home_url(): void {
+                $encoded_home_url = 'https%3A%2F%2Fexample.com%2Fdownload%252Ffile';
+
+                when( 'get_option' )->alias(
+                        static function ( string $option, $default_value = false ) {
+                                if ( 'blog_public' === $option ) {
+                                        return '1';
+                                }
+
+                                if ( Options::OPTION_KEY === $option ) {
+                                        return array(
+                                                'performance' => array(
+                                                        'enable_psi'  => true,
+                                                        'psi_api_key' => 'abc123',
+                                                ),
+                                        );
+                                }
+
+                                return $default_value;
+                        }
+                );
+
+                when( 'home_url' )->justReturn( $encoded_home_url );
+
+                $captured_args = null;
+                when( 'add_query_arg' )->alias(
+                        static function ( array $args, string $url ) use ( &$captured_args ): string {
+                                $captured_args = $args;
+
+                                return $url . '?' . http_build_query( $args );
+                        }
+                );
+
+                when( 'wp_remote_get' )->justReturn(
+                        array(
+                                'body' => wp_json_encode(
+                                        array(
+                                                'lighthouseResult' => array(
+                                                        'categories' => array(
+                                                                'performance' => array(
+                                                                        'score' => 0.95,
+                                                                ),
+                                                        ),
+                                                ),
+                                        )
+                                ),
+                        )
+                );
+
+                $health = new SeoHealth();
+                $result = $health->run_performance_test();
+
+                self::assertIsArray( $captured_args );
+                self::assertArrayHasKey( 'url', $captured_args );
+                self::assertSame( 'https://example.com/download%2Ffile', $captured_args['url'] );
+                self::assertSame( 'good', $result['status'] );
+        }
+
+        public function test_run_performance_test_collapses_double_encoded_reserved_sequences(): void {
+                when( 'get_option' )->alias(
+                        static function ( string $option, $default_value = false ) {
+                                if ( 'blog_public' === $option ) {
+                                        return '1';
+                                }
+
+                                if ( Options::OPTION_KEY === $option ) {
+                                        return array(
+                                                'performance' => array(
+                                                        'enable_psi'  => true,
+                                                        'psi_api_key' => 'abc123',
+                                                ),
+                                        );
+                                }
+
+                                return $default_value;
+                        }
+                );
+
+                when( 'home_url' )->justReturn( 'https://example.com/download%252Ffile/?q=cat%252Bdog' );
+
+                $captured_args = null;
+                when( 'add_query_arg' )->alias(
+                        static function ( array $args, string $url ) use ( &$captured_args ): string {
+                                $captured_args = $args;
+
+                                return $url . '?' . http_build_query( $args );
+                        }
+                );
+
+                when( 'wp_remote_get' )->justReturn(
+                        array(
+                                'body' => wp_json_encode(
+                                        array(
+                                                'lighthouseResult' => array(
+                                                        'categories' => array(
+                                                                'performance' => array(
+                                                                        'score' => 0.95,
+                                                                ),
+                                                        ),
+                                                ),
+                                        )
+                                ),
+                        )
+                );
+
+                $health = new SeoHealth();
+                $health->run_performance_test();
+
+                self::assertIsArray( $captured_args );
+                self::assertArrayHasKey( 'url', $captured_args );
+                self::assertSame( 'https://example.com/download%2Ffile/?q=cat%2Bdog', $captured_args['url'] );
+        }
 }

--- a/tests/unit/Utils/UrlNormalizerTest.php
+++ b/tests/unit/Utils/UrlNormalizerTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * URL normalizer tests.
+ *
+ * @package FP\SEO\Tests
+ */
+
+declare(strict_types=1);
+
+namespace FP\SEO\Tests\Unit\Utils;
+
+use Brain\Monkey;
+use FP\SEO\Utils\UrlNormalizer;
+use PHPUnit\Framework\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \FP\SEO\Utils\UrlNormalizer
+ */
+class UrlNormalizerTest extends TestCase {
+        protected function setUp(): void {
+                parent::setUp();
+                Monkey\setUp();
+
+                when( 'wp_parse_url' )->alias(
+                        static function ( $url ) {
+                                return parse_url( (string) $url );
+                        }
+                );
+        }
+
+        protected function tearDown(): void {
+                Monkey\tearDown();
+                parent::tearDown();
+        }
+
+        public function test_preserves_reserved_path_encodings(): void {
+                $url = 'https://example.com/download/%2Fsecret%2Ftoken%3Dabc';
+
+                self::assertSame(
+                        $url,
+                        UrlNormalizer::normalize( $url )
+                );
+        }
+
+        public function test_decodes_percent_encoded_hosts(): void {
+                $url      = 'https://%65xample.com/download/';
+                $expected = 'https://example.com/download/';
+
+                self::assertSame(
+                        $expected,
+                        UrlNormalizer::normalize( $url )
+                );
+        }
+
+        public function test_decodes_safe_path_and_query_characters(): void {
+                $url      = 'https://user%3Aname:p%40ss@example.com/path%20with%20space/%E2%82%AC?name=J%C3%B6rg';
+                $expected = 'https://user%3Aname:p%40ss@example.com/path with space/€?name=Jörg';
+
+                self::assertSame(
+                        $expected,
+                        UrlNormalizer::normalize( $url )
+                );
+        }
+
+        public function test_preserves_plus_sign_query_encodings(): void {
+                $url = 'https://example.com/?q=cat%2Bdog';
+
+                self::assertSame(
+                        $url,
+                        UrlNormalizer::normalize( $url )
+                );
+        }
+
+        public function test_collapses_double_encoded_reserved_sequences(): void {
+                $url      = 'https://example.com/download%252Ffile/?q=cat%252Bdog#section%252F1';
+                $expected = 'https://example.com/download%2Ffile/?q=cat%2Bdog#section%2F1';
+
+                self::assertSame(
+                        $expected,
+                        UrlNormalizer::normalize( $url )
+                );
+        }
+
+        public function test_decodes_double_encoded_safe_sequences(): void {
+                $url      = 'https://example.com/path%2520with%2520space/?name=J%C3%B6rg%2520M%C3%BCller';
+                $expected = 'https://example.com/path with space/?name=Jörg Müller';
+
+                self::assertSame(
+                        $expected,
+                        UrlNormalizer::normalize( $url )
+                );
+        }
+
+        public function test_preserves_reserved_fragment_encodings(): void {
+                $url = 'https://example.com/page#section%2F1%3Fmode%3Dfull';
+
+                self::assertSame(
+                        $url,
+                        UrlNormalizer::normalize( $url )
+                );
+        }
+
+        public function test_does_not_add_authority_separator_for_non_hierarchical_schemes(): void {
+                $url      = 'mailto:user%40example.com?subject=Hello%20World';
+                $expected = 'mailto:user@example.com?subject=Hello World';
+
+                self::assertSame(
+                        $expected,
+                        UrlNormalizer::normalize( $url )
+                );
+        }
+
+        public function test_decodes_fully_encoded_absolute_urls(): void {
+                $url      = 'https%3A%2F%2Fexample.com%2Fdownload%252Ffile';
+                $expected = 'https://example.com/download%2Ffile';
+
+                self::assertSame(
+                        $expected,
+                        UrlNormalizer::normalize( $url )
+                );
+        }
+
+        public function test_decodes_fully_encoded_non_hierarchical_urls(): void {
+                $url      = 'mailto%3Auser%40example.com%3Fsubject%3DHello%2520World';
+                $expected = 'mailto:user@example.com?subject=Hello World';
+
+                self::assertSame(
+                        $expected,
+                        UrlNormalizer::normalize( $url )
+                );
+        }
+}


### PR DESCRIPTION
## Summary
- decode percent-encoded hosts when normalizing URLs so outbound PSI requests use valid domains
- cover percent-encoded host handling in the shared normalizer plus the performance signals and Site Health PSI flows

## Testing
- composer test
- php -d memory_limit=1G vendor/bin/phpstan analyse --configuration=phpstan.neon

------
https://chatgpt.com/codex/tasks/task_e_68dce74bbbb8832fb1bdf7f9696ecdb5