### PR TITLE
Add build tooling and packaging workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/tests export-ignore
+/docs export-ignore
+/.github export-ignore
+/node_modules export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -1,0 +1,76 @@
+name: Build plugin zip
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: zip
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader
+          composer dump-autoload -o --classmap-authoritative
+
+      - name: Prepare build directory
+        env:
+          PLUGIN_SLUG: fp-seo-performance
+        run: |
+          BUILD_DIR="build/${PLUGIN_SLUG}"
+          rm -rf "$BUILD_DIR"
+          mkdir -p "$BUILD_DIR"
+          rsync -a --delete \
+            --exclude=.git/ \
+            --exclude=.github/ \
+            --exclude=tests/ \
+            --exclude=docs/ \
+            --exclude=node_modules/ \
+            --exclude=*.md \
+            --exclude=.idea/ \
+            --exclude=.vscode/ \
+            --exclude=build/ \
+            --exclude=.gitattributes \
+            --exclude=.gitignore \
+            --exclude=.codex-state.json \
+            --exclude=build.sh \
+            --exclude=tools/ \
+            --exclude=composer.json \
+            --exclude=composer.lock \
+            --exclude=phpcs.xml \
+            --exclude=phpstan.neon \
+            --exclude=phpstan-bootstrap.php \
+            --exclude=phpunit.xml.dist \
+            --exclude=rector.php \
+            --exclude=README-BUILD.md \
+            --exclude=README.md \
+            ./ "$BUILD_DIR/"
+
+      - name: Create zip
+        id: zip
+        env:
+          PLUGIN_SLUG: fp-seo-performance
+        run: |
+          cd build
+          ZIP_NAME="${PLUGIN_SLUG}-${GITHUB_REF_NAME}.zip"
+          zip -rq "$ZIP_NAME" "$PLUGIN_SLUG"
+          echo "zip_name=${ZIP_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-zip
+          path: build/${{ steps.zip.outputs.zip_name }}
+          if-no-files-found: error

--- a/README-BUILD.md
+++ b/README-BUILD.md
@@ -1,0 +1,27 @@
+# Build & Release Guide
+
+## Prerequisites
+
+- PHP 8.2 (compatible with PHP 8.0+) with the `zip` extension enabled
+- Composer 2
+- Bash shell with `rsync` and `zip`
+
+## Local build workflow
+
+```bash
+bash build.sh --bump=patch
+```
+
+or set an explicit version:
+
+```bash
+bash build.sh --set-version=1.2.3
+```
+
+The script will install dependencies without dev packages, optimise the autoloader, stage runtime files in `build/fp-seo-performance/`, and produce a timestamped ZIP archive inside `build/`.
+
+The output will report the final version and the generated ZIP path.
+
+## GitHub Action release
+
+Create and push a tag following the `v*` pattern (for example `v1.2.3`). The `build-plugin-zip` workflow builds the plugin with the same excludes used locally and uploads the ZIP as an artifact named `plugin-zip`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # FP-SEO-Manager
+
+## Release process
+
+1. Ensure prerequisites from [README-BUILD](README-BUILD.md) are available.
+2. Run the build script to bump the version (patch by default) and generate the ZIP:
+   ```bash
+   bash build.sh --bump=patch
+   ```
+   or set an explicit version:
+   ```bash
+   bash build.sh --set-version=1.2.3
+   ```
+3. Commit the bumped version and generated artifacts.
+4. (Optional) Push a tag like `v1.2.3` to trigger the GitHub Action that uploads the packaged ZIP artifact.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$ROOT_DIR/tools"
+
+find_plugin_file() {
+    local file
+    while IFS= read -r -d '' file; do
+        if grep -qi "^\s*\*\s*Plugin Name:" "$file"; then
+            echo "$(basename "$file")"
+            return 0
+        fi
+    done < <(find "$ROOT_DIR" -maxdepth 1 -type f -name '*.php' -print0)
+
+    echo "Unable to locate main plugin file." >&2
+    return 1
+}
+
+PLUGIN_FILE="$(find_plugin_file)"
+if [[ -z "$PLUGIN_FILE" ]]; then
+    echo "Failed to identify plugin file." >&2
+    exit 1
+fi
+
+PLUGIN_SLUG="${PLUGIN_FILE%.php}"
+
+SET_VERSION=""
+BUMP_TYPE="patch"
+ZIP_NAME=""
+
+usage() {
+    cat <<'EOF'
+Usage: bash build.sh [options]
+
+Options:
+  --set-version=X.Y.Z  Set the plugin version explicitly.
+  --bump=TYPE          Bump the plugin version (patch, minor, major). Default: patch.
+  --zip-name=NAME      Custom name for the output zip file (without path).
+  -h, --help           Show this help message.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --set-version=*)
+            SET_VERSION="${1#*=}"
+            shift
+            ;;
+        --bump=*)
+            BUMP_TYPE="${1#*=}"
+            shift
+            ;;
+        --zip-name=*)
+            ZIP_NAME="${1#*=}"
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+NEW_VERSION=""
+
+if [[ -n "$SET_VERSION" ]]; then
+    NEW_VERSION="$(php "$TOOLS_DIR/bump-version.php" --set-version="$SET_VERSION")"
+elif [[ -n "$BUMP_TYPE" ]]; then
+    case "$BUMP_TYPE" in
+        major|minor|patch)
+            ;;
+        *)
+            echo "Invalid bump type: $BUMP_TYPE" >&2
+            exit 1
+            ;;
+    esac
+    NEW_VERSION="$(php "$TOOLS_DIR/bump-version.php" --bump="$BUMP_TYPE")"
+else
+    NEW_VERSION="$(php "$TOOLS_DIR/bump-version.php" --bump=patch)"
+fi
+
+if [[ -z "$NEW_VERSION" ]]; then
+    echo "Unable to determine new version." >&2
+    exit 1
+fi
+
+echo "Using version: $NEW_VERSION"
+
+composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader
+composer dump-autoload -o --classmap-authoritative
+
+BUILD_ROOT="$ROOT_DIR/build"
+TARGET_DIR="$BUILD_ROOT/$PLUGIN_SLUG"
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+
+RSYNC_EXCLUDES=(
+    "--exclude=.git/"
+    "--exclude=.github/"
+    "--exclude=tests/"
+    "--exclude=docs/"
+    "--exclude=node_modules/"
+    "--exclude=*.md"
+    "--exclude=.idea/"
+    "--exclude=.vscode/"
+    "--exclude=build/"
+    "--exclude=.gitattributes"
+    "--exclude=.gitignore"
+    "--exclude=.codex-state.json"
+    "--exclude=build.sh"
+    "--exclude=tools/"
+    "--exclude=composer.json"
+    "--exclude=composer.lock"
+    "--exclude=phpcs.xml"
+    "--exclude=phpstan.neon"
+    "--exclude=phpstan-bootstrap.php"
+    "--exclude=phpunit.xml.dist"
+    "--exclude=rector.php"
+    "--exclude=README-BUILD.md"
+    "--exclude=README.md"
+)
+
+rsync -a --delete "${RSYNC_EXCLUDES[@]}" "$ROOT_DIR/" "$TARGET_DIR/"
+
+TIMESTAMP="$(date +"%Y%m%d%H%M")"
+ZIP_BASENAME="$PLUGIN_SLUG-$TIMESTAMP.zip"
+if [[ -n "$ZIP_NAME" ]]; then
+    ZIP_BASENAME="$ZIP_NAME"
+fi
+
+pushd "$BUILD_ROOT" > /dev/null
+rm -f "$ZIP_BASENAME"
+zip -rq "$ZIP_BASENAME" "$PLUGIN_SLUG"
+popd > /dev/null
+
+ZIP_PATH="$BUILD_ROOT/$ZIP_BASENAME"
+
+echo "Created archive: $ZIP_PATH"
+echo "Version: $NEW_VERSION"
+
+ls "$TARGET_DIR"

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,11 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "phpstan/extension-installer": true
-        }
+        },
+        "platform": {
+            "php": "8.2.0"
+        },
+        "optimize-autoloader": true,
+        "sort-packages": true
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1aad09bb2ed04a4f18290a51b7c74f4",
+    "content-hash": "8e073a2ff61c013a9ea07dbab326bcb3",
     "packages": [],
     "packages-dev": [
         {
@@ -2758,5 +2758,8 @@
         "php": "^8.0"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.2.0"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/fp-seo-performance.php
+++ b/fp-seo-performance.php
@@ -3,7 +3,7 @@
  * Plugin Name: FP SEO Performance
  * Plugin URI: https://example.com/plugins/fp-seo-performance
  * Description: SEO and performance assistant for WordPress editors.
- * Version: 0.1.0
+ * Version: 0.1.2
  * Author: FP
  * Author URI: https://example.com
  * Text Domain: fp-seo-performance

--- a/tools/bump-version.php
+++ b/tools/bump-version.php
@@ -1,0 +1,165 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+function error(string $message): void {
+    fwrite(STDERR, $message . PHP_EOL);
+    exit(1);
+}
+
+function findPluginFile(string $root): string {
+    $candidates = glob($root . DIRECTORY_SEPARATOR . '*.php');
+    if ($candidates === false) {
+        error('Unable to scan plugin root for PHP files.');
+    }
+
+    foreach ($candidates as $candidate) {
+        $handle = @fopen($candidate, 'rb');
+        if ($handle === false) {
+            continue;
+        }
+
+        $header = fread($handle, 8192) ?: '';
+        fclose($handle);
+
+        if (preg_match('/Plugin Name\s*:/i', (string) $header) === 1) {
+            return $candidate;
+        }
+    }
+
+    error('Unable to locate the main plugin file.');
+}
+
+function parseOptions(): array {
+    $options = getopt('', [
+        'set:',
+        'set-version:',
+        'bump:',
+        'major',
+        'minor',
+        'patch',
+    ]);
+
+    if ($options === false) {
+        error('Failed to parse options.');
+    }
+
+    $setVersion = $options['set'] ?? $options['set-version'] ?? null;
+
+    if (is_array($setVersion)) {
+        error('Multiple --set options provided.');
+    }
+
+    if (is_string($setVersion)) {
+        $setVersion = trim($setVersion);
+    }
+
+    $bump = $options['bump'] ?? null;
+
+    if (is_array($bump)) {
+        error('Multiple --bump options provided.');
+    }
+
+    if ($bump !== null) {
+        $bump = strtolower(trim((string) $bump));
+    }
+
+    foreach (['major', 'minor', 'patch'] as $key) {
+        if (array_key_exists($key, $options)) {
+            $bump = $key;
+        }
+    }
+
+    if ($setVersion !== null && $setVersion === '') {
+        error('Provided --set version is empty.');
+    }
+
+    if ($bump === null || $bump === '') {
+        $bump = 'patch';
+    }
+
+    if (! in_array($bump, ['major', 'minor', 'patch'], true)) {
+        error('Invalid bump type: ' . $bump);
+    }
+
+    return [$setVersion, $bump];
+}
+
+function normalizeVersion(string $version): string {
+    if (! preg_match('/^\d+\.\d+\.\d+$/', $version)) {
+        error('Version must follow semantic versioning (X.Y.Z).');
+    }
+
+    return $version;
+}
+
+function incrementVersion(string $version, string $type): string {
+    [$major, $minor, $patch] = array_map('intval', explode('.', $version));
+
+    switch ($type) {
+        case 'major':
+            $major++;
+            $minor = 0;
+            $patch = 0;
+            break;
+        case 'minor':
+            $minor++;
+            $patch = 0;
+            break;
+        case 'patch':
+            $patch++;
+            break;
+        default:
+            error('Unsupported bump type: ' . $type);
+    }
+
+    return sprintf('%d.%d.%d', $major, $minor, $patch);
+}
+
+[$setVersion, $bump] = parseOptions();
+$root = dirname(__DIR__);
+$pluginFile = findPluginFile($root);
+
+$contents = file_get_contents($pluginFile);
+
+if ($contents === false) {
+    error('Unable to read plugin file: ' . $pluginFile);
+}
+
+$hasBom = str_starts_with($contents, "\u{FEFF}");
+
+if ($hasBom) {
+    $contents = substr($contents, 3);
+}
+
+$lineEnding = str_contains($contents, "\r\n") ? "\r\n" : "\n";
+
+if (! preg_match('/^(?<prefix>\s*\*\s*Version:\s*)(?<version>\d+\.\d+\.\d+)(?<suffix>.*)$/m', $contents, $matches, PREG_OFFSET_CAPTURE)) {
+    error('Unable to find Version header in plugin file: ' . $pluginFile);
+}
+
+$currentVersion = $matches['version'][0];
+$newVersion = $setVersion !== null ? normalizeVersion($setVersion) : incrementVersion($currentVersion, $bump);
+
+if ($newVersion === $currentVersion) {
+    echo $newVersion . PHP_EOL;
+    exit(0);
+}
+
+$replacement = $matches['prefix'][0] . $newVersion . $matches['suffix'][0];
+$start = $matches[0][1];
+$length = strlen($matches[0][0]);
+
+$updated = substr_replace($contents, $replacement, $start, $length);
+
+if ($hasBom) {
+    $updated = "\u{FEFF}" . $updated;
+}
+
+$updated = str_replace(["\r\n", "\n"], $lineEnding, $updated);
+
+if (file_put_contents($pluginFile, $updated) === false) {
+    error('Unable to write updated version to plugin file.');
+}
+
+echo $newVersion . PHP_EOL;


### PR DESCRIPTION
## Summary
- adjust Composer configuration for PHP 8.2 platform requirements and optimized autoloading
- add a PHP bump-version utility, build script, and packaging excludes for clean plugin zips
- document the release process and add a GitHub Action to generate artifacts on tags

## Testing
- composer validate
- bash build.sh --bump=patch

------
https://chatgpt.com/codex/tasks/task_e_68dd36ef6a74832f95ffe615edd4c8d3