### PR TITLE
Fix HTML helper coding standards

### DIFF
--- a/src/Utils/Assets.php
+++ b/src/Utils/Assets.php
@@ -26,85 +26,85 @@ class Assets {
 	/**
 	 * Hooks asset registration into admin requests.
 	 */
-        public function register(): void {
-                add_action( 'admin_init', array( $this, 'register_admin_assets' ), 10, 0 );
-                add_action( 'admin_enqueue_scripts', array( $this, 'ensure_admin_handles' ), 5, 0 );
-        }
+	public function register(): void {
+		add_action( 'admin_init', array( $this, 'register_admin_assets' ), 10, 0 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'ensure_admin_handles' ), 5, 0 );
+	}
 
-        /**
-         * Registers admin asset handles early in the request.
-         */
-        public function register_admin_assets(): void {
-                $this->register_handles();
-        }
+	/**
+	 * Registers admin asset handles early in the request.
+	 */
+	public function register_admin_assets(): void {
+		$this->register_handles();
+	}
 
-        /**
-         * Ensures admin handles exist before other callbacks enqueue them.
-         */
-        public function ensure_admin_handles(): void {
-                if ( $this->handles_registered() ) {
-                        return;
-                }
+	/**
+	 * Ensures admin handles exist before other callbacks enqueue them.
+	 */
+	public function ensure_admin_handles(): void {
+		if ( $this->handles_registered() ) {
+			return;
+		}
 
-                $this->register_handles();
-        }
+		$this->register_handles();
+	}
 
-        /**
-         * Registers asset handles used across admin screens.
-         */
-        private function register_handles(): void {
-                $version = $this->asset_version();
+	/**
+	 * Registers asset handles used across admin screens.
+	 */
+	private function register_handles(): void {
+		$version = $this->asset_version();
 
-                wp_register_style(
-                        'fp-seo-performance-admin',
-                        plugins_url( 'assets/admin/admin.css', FP_SEO_PERFORMANCE_FILE ),
-                        array(),
-                        $version
-                );
+		wp_register_style(
+			'fp-seo-performance-admin',
+			plugins_url( 'assets/admin/admin.css', FP_SEO_PERFORMANCE_FILE ),
+			array(),
+			$version
+		);
 
-                wp_register_script(
-                        'fp-seo-performance-admin',
-                        plugins_url( 'assets/admin/admin.js', FP_SEO_PERFORMANCE_FILE ),
-                        array( 'jquery' ),
-                        $version,
-                        true
-                );
+		wp_register_script(
+			'fp-seo-performance-admin',
+			plugins_url( 'assets/admin/admin.js', FP_SEO_PERFORMANCE_FILE ),
+			array( 'jquery' ),
+			$version,
+			true
+		);
 
-                wp_register_script(
-                        'fp-seo-performance-editor',
-                        plugins_url( 'assets/admin/editor-metabox.js', FP_SEO_PERFORMANCE_FILE ),
-                        array( 'jquery' ),
-                        $version,
-                        true
-                );
+		wp_register_script(
+			'fp-seo-performance-editor',
+			plugins_url( 'assets/admin/editor-metabox.js', FP_SEO_PERFORMANCE_FILE ),
+			array( 'jquery' ),
+			$version,
+			true
+		);
 
-                wp_register_script(
-                        'fp-seo-performance-bulk',
-                        plugins_url( 'assets/admin/bulk-auditor.js', FP_SEO_PERFORMANCE_FILE ),
-                        array( 'jquery' ),
-                        $version,
-                        true
-                );
-        }
+		wp_register_script(
+			'fp-seo-performance-bulk',
+			plugins_url( 'assets/admin/bulk-auditor.js', FP_SEO_PERFORMANCE_FILE ),
+			array( 'jquery' ),
+			$version,
+			true
+		);
+	}
 
-        /**
-         * Determines whether all admin handles are registered.
-         */
-        private function handles_registered(): bool {
-                return wp_style_is( 'fp-seo-performance-admin', 'registered' )
-                        && wp_script_is( 'fp-seo-performance-admin', 'registered' )
-                        && wp_script_is( 'fp-seo-performance-editor', 'registered' )
-                        && wp_script_is( 'fp-seo-performance-bulk', 'registered' );
-        }
+	/**
+	 * Determines whether all admin handles are registered.
+	 */
+	private function handles_registered(): bool {
+		return wp_style_is( 'fp-seo-performance-admin', 'registered' )
+			&& wp_script_is( 'fp-seo-performance-admin', 'registered' )
+			&& wp_script_is( 'fp-seo-performance-editor', 'registered' )
+			&& wp_script_is( 'fp-seo-performance-bulk', 'registered' );
+	}
 
-        /**
-         * Resolve the version string used for asset registration.
-         */
-        private function asset_version(): string {
-                if ( defined( 'FP_SEO_PERFORMANCE_VERSION' ) && '' !== FP_SEO_PERFORMANCE_VERSION ) {
-                        return FP_SEO_PERFORMANCE_VERSION;
-                }
+	/**
+	 * Resolve the version string used for asset registration.
+	 */
+	private function asset_version(): string {
+		if ( defined( 'FP_SEO_PERFORMANCE_VERSION' ) && '' !== FP_SEO_PERFORMANCE_VERSION ) {
+			return FP_SEO_PERFORMANCE_VERSION;
+		}
 
-                return '0.1.0';
-        }
+		return '0.1.0';
+	}
 }

--- a/src/Utils/Html.php
+++ b/src/Utils/Html.php
@@ -7,48 +7,58 @@
  * @link https://francescopasseri.com
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace FP\SEO\Utils;
 
-use const ENT_QUOTES;
-use const ENT_SUBSTITUTE;
+use Throwable;
+
 use function esc_html;
 use function function_exists;
 use function get_bloginfo;
 use function htmlspecialchars;
-use Throwable;
+
+use const ENT_QUOTES;
+use const ENT_SUBSTITUTE;
 
 /**
  * Helper utilities for rendering sanitized HTML.
  */
 class Html {
-    /**
-     * Escapes text for safe HTML output.
-     *
-     * @param string|null $text Raw text.
-     */
-    public static function esc_text(?string $text): string {
-        $value = $text ?? '';
+	/**
+	 * Escapes text for safe HTML output.
+	 *
+	 * @param string|null $text Raw text.
+	 */
+	public static function esc_text( ?string $text ): string {
+		$value   = $text ?? '';
+		$charset = self::detect_charset();
 
-        if (defined('ABSPATH') && function_exists('esc_html')) {
-            try {
-                return esc_html($value);
-            } catch (Throwable $exception) {
-                // Fall through to the HTML-escaping fallback.
-            }
-        }
+		if ( defined( 'ABSPATH' ) && function_exists( 'esc_html' ) ) {
+			try {
+				return esc_html( $value );
+			} catch ( Throwable $exception ) {
+				return htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE, $charset );
+			}
+		}
 
-        $charset = 'UTF-8';
+		return htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE, $charset );
+	}
 
-        if (defined('ABSPATH') && function_exists('get_bloginfo')) {
-            $blog_charset = (string) get_bloginfo('charset');
+	/**
+	 * Determine the charset to use for manual HTML escaping.
+	 */
+	private static function detect_charset(): string {
+		$charset = 'UTF-8';
 
-            if ('' !== $blog_charset) {
-                $charset = $blog_charset;
-            }
-        }
+		if ( defined( 'ABSPATH' ) && function_exists( 'get_bloginfo' ) ) {
+			$blog_charset = (string) get_bloginfo( 'charset' );
 
-        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, $charset);
-    }
+			if ( '' !== $blog_charset ) {
+				return $blog_charset;
+			}
+		}
+
+		return $charset;
+	}
 }


### PR DESCRIPTION
## Summary
- reorder the Html helper imports and spacing to satisfy the project coding standards
- refactor Html::esc_text to compute the charset in a helper and return the fallback escape when esc_html fails, eliminating the empty catch warning

## Testing
- vendor/bin/phpcs src/Utils/Assets.php src/Utils/Html.php

------
https://chatgpt.com/codex/tasks/task_e_68deb1f1ce60832faea82f0ef5b484a7